### PR TITLE
Fixing link to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Step - 3 : Predefine registers
 The default configuration file is configured to initialize every register with a `0x0000`.
 To set register values, you need to create your own configuration file.
 
-An example can be found in the GIT repo: [abb_coretec_example.json](https://bitbucket.org/Cybcon/modbus-server/src/master/examples/abb_coretec_example.json)
+An example can be found in the GIT repo: [abb_coretec_example.json](./examples/abb_coretec_example.json)
 
 ```bash
 docker run --rm -p 5020:5020 -v ./server_config.json:/server_config.json oitc/modbus-server:latest -f /server_config.json


### PR DESCRIPTION
# Summary

Fixxing issue #16 - the path to the example configuration file `abb_coretec_example.json` pointing to the old Bitbucket GIT repository. The fixed one is pointing to the current repo - using a relative notation.